### PR TITLE
Improve error handling and fix decoding problem

### DIFF
--- a/Sources/MMDB/Decoder.swift
+++ b/Sources/MMDB/Decoder.swift
@@ -1,0 +1,270 @@
+import Foundation
+
+/// Used for decoding data from a file stream.
+public struct Decoder {
+    /// The file stream consisting of the MMDB database file.
+    var fileStream: FileStream
+    
+    /// The data field type tag read from the MMDB file as given in *MaxMind DB File Format Specification 2.0*
+    enum FieldType: UInt8 {
+        case extended = 0
+        case pointer = 1
+        case string = 2
+        case double = 3
+        case bytes = 4
+        case uint16 = 5
+        case uint32 = 6
+        case map = 7
+        case int32 = 8
+        case uint64 = 9
+        case uint128 = 10
+        case array = 11
+        case container = 12
+        case endMarker = 13
+        case boolean = 14
+        case float = 15
+    }
+    
+    /// A *value* read from an MMDB file. This parallels the `FieldType` tags, but includes an associated value
+    /// and you can't mix rawValues and associated values
+    public indirect enum Value {
+        case string(String)
+        case map([String:Value])
+        case uint16(UInt16)
+        case uint32(UInt32)
+        case uint64(UInt64)
+        case uint128(high: UInt64, low: UInt64)
+        case int32(Int32)
+        case double(Double)
+        case float(Float)
+        case bytes([UInt8])
+        case array([Value])
+        case boolean(Bool)
+        
+        /// Dump out a value using print().
+        ///
+        /// Just a little gift to developers, mostly so you can call it from the debugger.
+        /// - Parameter level: The indentation level, roughly speaking, two spaces per indent level.
+        func dump(level: Int = 0) {
+            let indent = String(repeating: "  ", count: level)
+            switch self {
+            case .string(let s):
+                print( "\(indent)\"\(s)\"")
+            case .map(let m):
+                print( "\(indent){")
+                for (k,v) in m {
+                    print( "\(indent): \(k) = ")
+                    v.dump(level: level+1)
+                }
+                print( "\(indent)}")
+            case .uint16(let v):
+                print( "\(indent)\(v) u16")
+            case .uint32(let v):
+                print( "\(indent)\(v) u32")
+            case .uint64(let v):
+                print( "\(indent)\(v) u64")
+            case .uint128(high: let high, low: let low):
+                print( "\(indent)0x\(String(format:"%08x%08x", high, low)) u128")
+            case .int32(let v):
+                print( "\(indent)\(v) i32")
+            case .double(let v):
+                print( "\(indent)\(v) double")
+            case .float(let v):
+                print( "\(indent)\(v) float")
+            case .bytes(let b):
+                print( "\(indent)[\(b.count) bytes]")
+            case .array(let elements):
+                print( "\(indent){")
+                elements.forEach{ $0.dump( level: level+1)}
+                print( "\(indent)}")
+            case .boolean(let v):
+                print( "\(indent)\(v ? "true" : "false")")
+            }
+        }
+    }
+    
+    init(fileStream: FileStream) {
+        self.fileStream = fileStream
+    }
+    
+    func decode(_ offset: inout Int, startingAt pointerBase: Int) throws -> Value {
+        guard fileStream.indices.contains(offset) else {
+            throw MMDBError.indexOutOfRange
+        }
+        let controlByte = fileStream[offset]
+        offset += 1
+        let fieldTypeValue = controlByte >> 5
+        guard var type = FieldType(rawValue: fieldTypeValue) else {
+            throw MMDBError.unknownFieldType(fieldTypeValue)
+        }
+        
+        if type == .pointer {
+            var pointer = try decodePointer(from: controlByte, with: pointerBase, at: &offset)
+            return try decode(&pointer, startingAt: pointerBase)
+        }
+        
+        if type == .extended {
+            let extendedFieldTypeValue = fileStream[offset] + 7
+            
+            guard extendedFieldTypeValue >= 8 else {
+                throw MMDBError.invalidFieldType(extendedFieldTypeValue)
+            }
+            
+            guard let newType = FieldType(rawValue: extendedFieldTypeValue) else {
+                throw MMDBError.unknownFieldType(extendedFieldTypeValue)
+            }
+            type = newType
+            offset += 1
+        }
+        let size = try sizeFromControlByte(controlByte: controlByte, offset: &offset)
+        return try decode(type, from: &offset, startingAt: pointerBase, with: size)
+    }
+    
+    func sizeFromControlByte(controlByte: UInt8, offset: inout Int) throws -> Int {
+        var size: Int = Int(controlByte) & 0x1f
+        let bytesToRead = size < 29 ? 0 : size - 28
+        let bytes = try fileStream.read(from: offset, numberOfBytes: Int(bytesToRead))
+        let decoded = Int(Self.decodeUInt32(from: bytes))
+        
+        if size == 29 {
+            size = 29 + decoded
+        } else if size == 30 {
+            size = 285 + decoded
+        } else if size == 31 {
+            size = (decoded & (0x0FFFFFFF >> (32 - (8 * bytesToRead)))) + 65821
+        }
+        offset += bytesToRead
+        return size
+    }
+    
+    func decode(_ type: FieldType, from offset: inout Int, startingAt pointerBase: Int, with size: Int) throws -> Value {
+        let bytes = try fileStream.read(from: offset, numberOfBytes: size)
+        
+        switch type {
+        case .map:
+            return .map(try decodeMap(of: size, from: &offset, startingAt: pointerBase))
+        case .array:
+            return .array(try decodeArray(of: size, from: &offset, startingAt: pointerBase))
+        case .boolean:
+            break
+        default:
+            offset += size
+        }
+        
+        switch type {
+        case .boolean:
+            return .boolean(Self.decodeBoolean(of: size))
+        case .string:
+            return .string(try Self.decodeString(from: bytes))
+        case .double:
+            return .double(try Self.decodeDouble(from: bytes))
+        case .bytes:
+            return .bytes(Array(bytes))
+        case .uint16:
+            return .uint16(Self.decodeUInt16(from: bytes))
+        case .uint32:
+            return .uint32(Self.decodeUInt32(from: bytes))
+        case .int32:
+            return .int32(Self.decodeInt32(from: bytes))
+        case .uint64:
+            return .uint64(Self.decodeUInt64(from: bytes))
+        case .uint128:
+            let uint128 = Self.decodeUInt128(from: bytes)
+            return .uint128(high: uint128.high, low: uint128.low)
+        case .float:
+            return .float(try Self.decodeFloat(from: bytes))
+        default:
+            throw MMDBError.unknownFieldType(type.rawValue)
+        }
+    }
+    
+    func decodePointer(from controlByte: UInt8, with pointerBase: Int, at offset: inout Int) throws -> Int {
+        let pointerSize = Int((controlByte >> 3) & 0x3)
+        let buffer = try fileStream.read(from: offset, numberOfBytes: pointerSize + 1)
+        offset += pointerSize + 1
+        let pointerOffsets = [0, 2048, 526336, 0]
+        
+        let packed: ArraySlice<UInt8>
+        if pointerSize == 3 {
+            packed = buffer
+        } else {
+            let pointerSizeBits = controlByte & 0x7
+            packed = [pointerSizeBits] + buffer
+        }
+        
+        let value = Int(Self.decodeUInt32(from: packed)) + pointerBase + pointerOffsets[pointerSize]
+        return value
+    }
+    
+    static func decodeString(from bytes: ArraySlice<UInt8>) throws -> String {
+        guard let string = String(bytes: bytes, encoding: .utf8) else {
+            throw MMDBError.decodingError("Could not decode string from bytes: \(bytes)")
+        }
+        return string
+    }
+    
+    static func decodeDouble(from bytes: ArraySlice<UInt8>) throws -> Double {
+        guard bytes.count == 8 else {
+            throw MMDBError.decodingError("Could not deocde double from bytes: \(bytes)")
+        }
+        return Double(bitPattern: decodeUInt64(from: bytes))
+    }
+    
+    static func decodeUInt16(from bytes: ArraySlice<UInt8>) -> UInt16 {
+        bytes.reduce(0) { ($0 << 8) | UInt16($1) }
+    }
+    
+    static func decodeUInt32(from bytes: ArraySlice<UInt8>) -> UInt32 {
+        bytes.reduce(0) { ($0 << 8) | UInt32($1) }
+    }
+    
+    func decodeMap(of size: Int, from offset: inout Int, startingAt pointerBase: Int) throws -> [String: Value] {
+        var map = [String: Value]()
+        for _ in 0..<size {
+            guard case let .string(key) = try decode(&offset, startingAt: pointerBase) else {
+                throw MMDBError.decodingError("Map key is no String at offset: \(offset)")
+            }
+            let value = try decode(&offset, startingAt: pointerBase)
+            map[key] = value
+        }
+        return map
+    }
+    
+    static func decodeInt32(from bytes: ArraySlice<UInt8>) -> Int32 {
+        Int32(bitPattern: decodeUInt32(from: bytes))
+    }
+    
+    static func decodeUInt64(from bytes: ArraySlice<UInt8>) -> UInt64 {
+        bytes.reduce(0) { ($0 << 8) | UInt64($1) }
+    }
+    
+    static func decodeUInt128(from bytes: ArraySlice<UInt8>) -> (high: UInt64, low: UInt64) {
+        var b = Array(bytes)
+        if bytes.count < 16 {
+            b = Array(repeating: 0, count: 16 - bytes.count) + b
+        }
+        let high = b[0..<8].reduce(0, { ($0 << 8) | UInt64($1) })
+        let low = b[8..<16].reduce(0, { ($0 << 8) | UInt64($1) })
+        return (high, low)
+    }
+    
+    func decodeArray(of size: Int, from offset: inout Int, startingAt pointerBase: Int) throws -> [Value] {
+        var array = [Value]()
+        for _ in 0..<size {
+            let value = try decode(&offset, startingAt: pointerBase)
+            array.append(value)
+        }
+        return array
+    }
+    
+    static func decodeBoolean(of size: Int) -> Bool {
+        size != 0
+    }
+    
+    static func decodeFloat(from bytes: ArraySlice<UInt8>) throws -> Float {
+        guard bytes.count == 4 else {
+            throw MMDBError.decodingError("Could not deocde float from bytes: \(bytes)")
+        }
+        return Float(bitPattern: decodeUInt32(from: bytes))
+    }
+}

--- a/Sources/MMDB/FileStream.swift
+++ b/Sources/MMDB/FileStream.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+class FileStream {
+    private var bytes: [UInt8]
+    
+    init(data: Data) {
+        bytes = data.withUnsafeBytes{ body in
+            let buffer = body.bindMemory(to: UInt8.self)
+            return .init(buffer)
+        }
+    }
+    
+    init(bytes: [UInt8]) {
+        self.bytes = bytes
+    }
+    
+    subscript(index: Int) -> UInt8 {
+        bytes[index]
+    }
+    
+    func read(from offset: Int, numberOfBytes: Int) throws -> ArraySlice<UInt8> {
+        guard offset + numberOfBytes <= bytes.count else {
+            throw MMDBError.indexOutOfRange
+        }
+        return bytes[offset..<offset + numberOfBytes]
+    }
+    
+    var count: Int { bytes.count }
+    
+    var indices: Range<Array<UInt8>.Index> { bytes.indices }
+    
+    func findMetadataStart() throws -> Int {
+        // This is "\xab\xcd\xefMaxMind.com" per the spec, but that is invalid UTF8, so we are kind of screwed there.
+        let marker : [UInt8] = [0xab, 0xcd, 0xef, 0x4D, 0x61, 0x78, 0x4D, 0x69, 0x6E, 0x64, 0x2E, 0x63, 0x6F, 0x6D]
+        
+        // Look back from the end of the file until we find the last match.
+        for i in (0 ..< bytes.count - marker.count).reversed()  {
+            guard bytes[i] == marker.first! else { continue }
+            if marker.indices.allSatisfy({ bytes[i + $0] == marker[$0]}) {
+                return i + marker.count
+            }
+        }
+        
+        throw MMDBError.metadataError("Could not find metadata")
+    }
+}

--- a/Sources/MMDB/GeoLite2.swift
+++ b/Sources/MMDB/GeoLite2.swift
@@ -18,18 +18,18 @@ import Foundation
 /// address. The `countryCode` method is just an encapsulation of a common use case.
 /// 
 public class GeoLite2CountryDatabase : MMDB {
-    override public init?( data: Data) {
-        super.init(data: data)
+    override public init(data: Data) throws {
+        try super.init(data: data)
         
         // check that we really the right database type
-        if databaseType != "GeoLite2-Country" { return nil }
+        if metadata.databaseType != "GeoLite2-Country" { throw MMDBError.invalidDatabaseType(metadata.databaseType) }
     }
 
     /// Do the search from ascii numeric internet address but just fetch out the ISO country code.
     /// - Parameter address: A numeric IPv4 or IPv6 address as accepted by `inet_addr`
     /// or `inet_pton`
     /// - Returns: A two letter ISO country code, capitalized, or nil if not found (or error)
-    public func countryCode( address: String) -> String? {
+    public func countryCode(address: String) throws -> String? {
         switch search(address: address) {
         case .notFound:
             return nil

--- a/Sources/MMDB/MMDB.swift
+++ b/Sources/MMDB/MMDB.swift
@@ -1,416 +1,45 @@
 import Foundation
+
 public class MMDB {
+    private let fileStream: FileStream
+    let metadata: Metadata
+    private let decoder: Decoder
+    private(set) lazy var ipv4Root: UInt = computeIPv4Root()
     
-    /// The data field type tag read from the MMDB file as given in *MaxMind DB File Format Specification 2.0*
-    enum FieldType : UInt8 {
-        case pointer = 1
-        case string = 2
-        case double = 3
-        case bytes = 4
-        case uint16 = 5
-        case uint32 = 6
-        case map = 7
-        case int32 = 8
-        case uint64 = 9
-        case uint128 = 10
-        case array = 11
-        case dataCacheContainer = 12
-        case endMarker = 13
-        case boolean = 14
-        case float = 15
+    /// Initializes a database from an url.
+    /// - Parameter url: The url at which the database file is located.
+    public convenience init(from url: URL) throws {
+        guard let data = try? Data(contentsOf: url) else {
+            throw MMDBError.notFound(url.absoluteString)
+        }
+        try self.init(data: data)
+    }
+    
+    /// Initializes a database from data.
+    /// - Parameter data: The data representing the MMDB.
+    public init(data: Data) throws {
+        self.fileStream = FileStream(data: data)
         
-        
-        /// Scan a Value once the FieldType is known.
-        /// - Parameters:
-        ///   - bytes: A slice of UInt8 which are the data
-        /// - Returns: Read a `MMDB.Value` from a block of bytes. Does not work for `.map`,  `.pointer`, and `.array`, only
-        ///   the simple types.
-        func scan( bytes: Array<UInt8>.SubSequence) -> Value? {
-            switch self {
-            case .string:
-                guard let s = String(bytes: Array(bytes), encoding: .utf8) else {
-                    return nil
-                }
-                return .string(s)
-            case .double:
-                if bytes.count != 8 {
-                    return nil
-                }
-                let r = bytes.reduce(0, { ($0 << 8) | UInt64($1)} )
-                
-                return .double( Double(bitPattern: r))
-            case .float:
-                if bytes.count != 4 {
-                    return nil
-                }
-                let r = bytes.reduce(0, { ($0 << 8) | UInt32($1)} )
-
-                return .float( Float(bitPattern: r))
-            case .bytes:
-                return .bytes( Array(bytes))
-            case .uint16:
-                return .uint16( bytes.reduce(0, { ($0 << 8) | UInt16($1)} ))
-            case .uint32:
-                return .uint32( bytes.reduce(0, { ($0 << 8) | UInt32($1)} ))
-            case .uint64:
-                return .uint64( bytes.reduce(0, { ($0 << 8) | UInt64($1)} ))
-            case .int32:
-                let u = bytes.reduce(0, { ($0 << 8) | UInt32($1)} )
-                if u & 0x80000000 == 0 {
-                    return .int32( Int32(u))
-                } else {
-                    return .int32( -Int32( ~u) - 1)
-                }
-            case .uint128:
-                var b = Array(bytes)
-                if bytes.count < 16 {
-                    b = Array( repeating: 0, count: 16 - bytes.count) + b
-                }
-                let high = b[0..<8].reduce(0, { ($0 << 8) | UInt64($1)} )
-                let low = b[8..<16].reduce(0, { ($0 << 8) | UInt64($1)} )
-                return .uint128(high: high, low: low)
-            case .dataCacheContainer:
-                fatalError("Field type '\(self)' not supported")
-            case .endMarker:
-                fatalError("Field type '\(self)' not supported")
-                
-            //
-            // `map` and `array` need to be able to recursively call into the
-            // Store's readValue function. They have to be handled at a higher
-            // level.
-            //
-            case .map:
-                fatalError("Field type '.map' can not be scanned by FieldType")
-            case .array:
-                fatalError("Field type '.array' can not be scanned by FieldType")
-            case .pointer:
-                fatalError("Field type '.map' can not be scanned by FieldType")
-            case .boolean:
-                fatalError("Field type '.boolean' can not be scanned by FieldType")
-            }
+        var metadataStart = try fileStream.findMetadataStart()
+        self.decoder = Decoder(fileStream: self.fileStream)
+        guard case let .map(metadataMap) = try decoder.decode(&metadataStart, startingAt: metadataStart) else {
+            throw MMDBError.metadataError("Could not decode metadata")
+        }
+        self.metadata = try Metadata(metadataMap)
+        if metadata.searchTreeSize > metadataStart {
+            throw MMDBError.corruptDatabase("Invalid node count")
         }
     }
     
-    
-    /// A *value* read from an MMDB file. This parallels the `FieldType` tags, but includes an associated value
-    /// and you can't mix rawValues and associated values
-    public indirect enum Value {
-        case string(String)
-        case map( [String:Value])
-        case uint16( UInt16)
-        case uint32( UInt32)
-        case uint64( UInt64)
-        case uint128( high: UInt64, low: UInt64)
-        case int32( Int32)
-        case double( Double)
-        case float( Float)
-        case bytes( [UInt8] )
-        case array( [Value])
-        case boolean( Bool)
-        
-        /// Dump out a value using print().
-        ///
-        /// Just a little gift to developers, mostly so you can call it from the debugger.
-        /// - Parameter level: The indentation level, roughly speaking, two spaces per indent level.
-        func dump(level: Int = 0) {
-            let indent = String(repeating: "  ", count: level)
-            switch self {
-            case .string(let s):
-                print( "\(indent)\"\(s)\"")
-            case .map(let m):
-                print( "\(indent){")
-                for (k,v) in m {
-                    print( "\(indent): \(k) = ")
-                    v.dump(level: level+1)
-                }
-                print( "\(indent)}")
-            case .uint16(let v):
-                print( "\(indent)\(v) u16")
-            case .uint32(let v):
-                print( "\(indent)\(v) u32")
-            case .uint64(let v):
-                print( "\(indent)\(v) u64")
-            case .uint128(high: let high, low: let low):
-                print( "\(indent)0x\(String(format:"%08x%08x", high, low)) u128")
-            case .int32(let v):
-                print( "\(indent)\(v) i32")
-            case .double(let v):
-                print( "\(indent)\(v) double")
-            case .float(let v):
-                print( "\(indent)\(v) float")
-            case .bytes(let b):
-                print( "\(indent)[\(b.count) bytes]")
-            case .array(let elements):
-                print( "\(indent){")
-                elements.forEach{ $0.dump( level: level+1)}
-                print( "\(indent)}")
-            case .boolean(let v):
-                print( "\(indent)\(v ? "true" : "false")")
-            }
-        }
-    }
-    
-    struct Store {
-        private let bytes : [UInt8]
-        
-        public init( data: Data) {
-            bytes = data.withUnsafeBytes{ (_ body: (UnsafeRawBufferPointer)) -> [UInt8] in
-                let buf = body.bindMemory(to: UInt8.self)
-                return .init( buf)
-            }
-        }
-        
-        func locateMetadata( ) -> Int? {
-            // This is "\xab\xcd\xefMaxMind.com" per the spec, but that is invalid UTF8, so we are kind of screwed there.
-            let marker : [UInt8] = [ 0xab, 0xcd, 0xef, 0x4D, 0x61, 0x78, 0x4D, 0x69, 0x6E, 0x64, 0x2E, 0x63, 0x6F, 0x6D ]
-            
-            // Look back from the end of the file until we find the last match.
-            for i in (0 ..< bytes.count - marker.count).reversed()  {
-                if bytes[i] != marker.first! { continue }
-                if marker.indices.allSatisfy({ bytes[i + $0] == marker[$0]}) {
-                    return i + marker.count
-                }
-            }
-
-            return nil
-        }
-
-        func readValue( pointer: inout Int, sectionStart: Int) -> Value? {
-            //
-            // Read the ControlByte
-            //
-            if !bytes.indices.contains(pointer) { return nil }
-            let controlByte = bytes[pointer]
-            pointer += 1
-            
-            let top3 = controlByte >> 5
-            let payloadSize0 = controlByte & 0x1f
-            let fieldType : FieldType
-            let payloadSize : Int
-
-            //
-            // Decode the FieldType
-            //
-            switch top3 {
-            case 0:
-                guard let ft = FieldType(rawValue: bytes[pointer] + 7) else {
-                    // invalid field type
-                    return nil
-                }
-                pointer += 1
-                fieldType = ft
-            default:
-                guard let ft = FieldType(rawValue: top3) else {
-                    return nil   // bad field type, really shouldn't be able to happen
-                }
-                fieldType = ft
-            }
-            
-            //
-            // .pointer is special! It interprets payloadSize0 differently, we can't let
-            // the payloadSize calculator eat bytes.
-            //
-            if fieldType == .pointer {
-                let b3 : UInt = UInt( payloadSize0 & 7)   // low three bits are going to end up on top of the size
-                let sz = (payloadSize0) >> 3 & 3   // which crazy size function will we use?
-                
-                switch sz {
-                case 0:
-                    if pointer >= bytes.count { return nil }
-                    let p = (b3 << 8) | UInt(bytes[pointer])
-                    pointer += 1
-                    var np : Int = sectionStart + Int(p)
-                    return readValue(pointer: &np, sectionStart: sectionStart)
-                case 1:
-                    if pointer + 1 >= bytes.count { return nil }
-                    let p = 2048 + ((b3 << 16) | ( UInt(bytes[pointer]) << 8) | UInt(bytes[pointer + 1]))
-                    pointer += 2
-                    var np : Int = sectionStart + Int(p)
-                    return readValue(pointer: &np, sectionStart: sectionStart)
-                case 2:
-                    if pointer + 2 >= bytes.count { return nil }
-                    let p = 526336 + ((b3 << 24) | ( UInt(bytes[pointer]) << 16) | (UInt(bytes[pointer + 1] << 8)) | UInt(bytes[pointer + 2]))
-                    pointer += 3
-                    var np : Int = sectionStart + Int(p)
-                    return readValue(pointer: &np, sectionStart: sectionStart)
-                case 3:
-                    if pointer + 3 >= bytes.count { return nil }
-                    let p = ( UInt(bytes[pointer]) << 24) | (UInt(bytes[pointer + 1]) << 16) |
-                    ( UInt(bytes[pointer + 2]) << 8 ) | UInt(bytes[pointer + 3])
-                    pointer += 4
-                    var np : Int = sectionStart + Int(p)
-                    return readValue(pointer: &np, sectionStart: sectionStart)
-                default:
-                    fatalError("The impossible has happened.")
-                }
-            }
-            
-            //
-            // Decode the payloadSize
-            //
-            switch payloadSize0 {
-            case 29:
-                if pointer >= bytes.count { return nil }
-                payloadSize = 29 + Int(bytes[pointer])
-                pointer += 1
-            case 30:
-                if pointer + 1 >= bytes.count { return nil }
-                payloadSize = 285 + (Int(bytes[pointer]) << 8) + Int(bytes[pointer+1])
-                pointer += 2
-            case 31:
-                if pointer + 2 >= bytes.count { return nil }
-                payloadSize = 65821 + (Int(bytes[pointer]) << 16) + (Int(bytes[pointer+1]) << 8) + Int(bytes[pointer+2])
-                pointer += 3
-            default:
-                payloadSize = Int(payloadSize0)
-            }
-
-            //
-            // Read the Value. map and array are special, we need to handle them so we can
-            // recurse. The rest of the field types are just scanned by their enum.
-            //
-            switch fieldType {
-            case .map:
-                var result : [String:Value] = [:]
-                for _ in 0 ..< payloadSize {
-                    guard case let .string(key) = readValue(pointer: &pointer, sectionStart: sectionStart) else {
-                        return nil   // key must be a string
-                    }
-                    guard let val = readValue(pointer: &pointer, sectionStart: sectionStart) else {
-                        return nil
-                    }
-                    result[key] = val
-                }
-                return .map(result)
-            case .array:
-                var result : [Value] = []
-                for _ in 0 ..< payloadSize {
-                    guard let val = readValue(pointer: &pointer, sectionStart: sectionStart) else {
-                        return nil
-                    }
-                    result.append(val)
-                }
-                return .array(result)
-            case .pointer:
-                let past = pointer + payloadSize - 1
-                if past > bytes.count { return nil }
-
-                let p = bytes[pointer ..< past].reduce(0, { ($0 << 8) | UInt($1)} )
-                pointer += payloadSize
-                
-                var np : Int = sectionStart + Int(p)
-                return readValue(pointer: &np, sectionStart: sectionStart)
-            case .boolean:
-                return .boolean( payloadSize != 0)
-            default:
-                let past = pointer + payloadSize
-                if past > bytes.count { return nil }
-                let r = fieldType.scan(bytes: bytes[pointer ..< past])
-                pointer += payloadSize
-                return r
-            }
-        }
-
-        func node6( _ number: UInt, side: UInt) -> UInt {
-            let base = Int(number * 6)
-            if side == 0 {
-                return ( (UInt(bytes[base]) << 16) | (UInt( bytes[base+1]) << 8) | UInt(bytes[base+2]))
-            } else {
-                return ( (UInt(bytes[base+3]) << 16) | (UInt( bytes[base+4]) << 8) | UInt(bytes[base+5]))
-            }
-        }
-        func node7( _ number: UInt, side: UInt) -> UInt {
-            let base = Int(number * 7)
-            if side == 0 {
-                return ( (UInt(bytes[base+3] >> 4 ) << 24) + (UInt(bytes[base]) << 16) | (UInt( bytes[base+1]) << 8) | UInt(bytes[base+2]))
-            } else {
-                return ( (UInt(bytes[base+3] & 0x0f ) << 24) + (UInt(bytes[base+4]) << 16) | (UInt( bytes[base+5]) << 8) | UInt(bytes[base+6]))
-            }
-        }
-        func node8( _ number: UInt, side: UInt) -> UInt {
-            let base = Int(number * 8)
-            if side == 0 {
-                return ( (UInt(bytes[base]) << 24) | (UInt(bytes[base+1]) << 16) | (UInt( bytes[base+2]) << 8) | UInt(bytes[base+3]))
-            } else {
-                return ( (UInt(bytes[base+4]) << 24) | (UInt(bytes[base+5]) << 16) | (UInt( bytes[base+6]) << 8) | UInt(bytes[base+7]))
-            }
-        }
-    }
-    
-    private let store : Store
-    let majorVersion : UInt
-    let minorVersion : UInt
-    let epoch : UInt
-    let ipVersion : UInt
-    let recordSize : UInt
-    let nodeCount : UInt
-    let databaseType : String
-    let dataSectionStart : UInt
-    
-    lazy var ipv4Root : UInt = computeIPv4Root()
-    
-    private let searchTreeSize : UInt
-    
-    public init?( data: Data) {
-        store = Store(data: data)
-        
-        guard let metadataOffset = store.locateMetadata() else {
-            return nil
-        }
-
-        var p = metadataOffset
-        guard case let .map(metadata) = store.readValue(pointer: &p, sectionStart: metadataOffset) else {
-            print("Unable to read metadata")
-            return nil
-        }
-        
-        guard case let .uint16(major) = metadata["binary_format_major_version"],
-              case let .uint16(minor) = metadata["binary_format_minor_version"] else {
-            print("no major and minor version")
-            return nil
-        }
-        
-        if major < 2 {
-            print("not major version 2")
-            return nil
-        }
-        
-        majorVersion = UInt(major)
-        minorVersion = UInt(minor)
-        
-        guard case let .uint64(epoch) = metadata["build_epoch"],
-              case let .uint16(ipVersion) = metadata["ip_version"],
-              case let .uint16(recordSize) = metadata["record_size"],
-              case let .uint32(nodeCount) = metadata["node_count"],
-              case let .string(databaseType) = metadata["database_type"] else {
-            print("Missing some metadata")
-            return nil
-        }
-        
-        self.epoch = UInt(epoch)
-        self.ipVersion = UInt(ipVersion)
-        self.recordSize = UInt(recordSize)
-        self.nodeCount = UInt(nodeCount)
-        self.databaseType = databaseType
-        
-        searchTreeSize = ( ( self.recordSize * 2 ) / 8 ) * self.nodeCount
-        
-        if searchTreeSize > metadataOffset {
-            return nil  // Can't be right.
-        }
-        
-        dataSectionStart = searchTreeSize + 16
-    }
-    
-    public convenience init?( from: URL) {
-        guard let d = try? Data( contentsOf: from) else {
-            return nil
-        }
-        self.init( data: d)
+    public enum SearchResult {
+        case notFound
+        case partial(UInt)
+        case value(Decoder.Value)
+        case failed(String)
     }
     
     func computeIPv4Root() -> UInt {
-        if ipVersion == 6,
+        if metadata.ipVersion == 6,
            case let .partial(zero64) = search(value: 0, bits: 64),
            case let .partial(zero96) = search(starting: zero64, value: 0, bits: 32) {
             return zero96
@@ -418,25 +47,50 @@ public class MMDB {
         return 0
     }
     
+    // MARK: - Search
     
-    private func node( _ number: UInt, side: UInt) -> UInt {
-        switch recordSize {
-        case 24:
-            return store.node6( number, side: side)
-        case 28:
-            return store.node7( number, side: side)
-        case 32:
-            return store.node8( number, side: side)
-        default:
-            fatalError("Unsupported record size")
+    /// Get the MMDB.Value record for an IP address in text form. Does not look up host names.
+    /// You will need to use a numeric form. It accepts both IPv4 and IPv6 addresses.
+    /// - Parameter address: A numeric IPv4 or IPv6 address as accepted by `inet_addr`
+    /// or `inet_pton`
+    /// - Returns: The MMDB.Value record found, or a .notFound, or maybe a .failure if your name
+    /// was not valid.
+    public func search(address: String) -> SearchResult {
+        let ipv4 = inet_addr(address)
+        if ipv4 != UInt32.max {
+            return search(starting: ipv4Root, value: UInt(ipv4.bigEndian)<<32, bits: 32)
         }
-    }
-    
-    public enum SearchResult {
-        case notFound
-        case partial(UInt)
-        case value(Value)
-        case failed(String)
+        
+        var ipv6 = in6_addr()
+        switch withUnsafeMutablePointer(to: &ipv6, ({ inet_pton(AF_INET6, address, UnsafeMutablePointer($0))})) {
+        case -1:
+            break  // error
+        case 0:
+            break  // not a valid address
+        default:
+#if canImport(Glibc)
+            let (a,b,c,d) = ipv6.__in6_u.__u6_addr32
+#else
+            let (a,b,c,d) = ipv6.__u6_addr.__u6_addr32
+#endif
+            let parts = [a.bigEndian, b.bigEndian, c.bigEndian, d.bigEndian]
+            var n : UInt = 0
+            for p in parts {
+                switch search(starting: n, value: UInt(p)<<32, bits: 32) {
+                    
+                case .notFound:
+                    return .notFound
+                case .partial(let nn):
+                    n = nn
+                case .value(let v):
+                    return .value(v)
+                case .failed(let m):
+                    return .failed(m)
+                }
+            }
+        }
+        
+        return .notFound
     }
     
     /// Search the database for a match.
@@ -457,8 +111,8 @@ public class MMDB {
     ///   a .partial result will be given at this point.
     /// - Returns: A `SearchResult`, so a value, a 'not found' indicator, a partial result marker, or a failure message.
     /// Failures should never occur in proper use of an uncorrupted database. You might get them during development.
-    func search( starting: UInt = 0, value: UInt, bits: Int) -> SearchResult {
-        if starting >= nodeCount {
+    func search(starting: UInt = 0, value: UInt, bits: Int) -> SearchResult {
+        if starting >= metadata.nodeCount {
             return .failed("Invalid starting node number")
         }
         if bits < 0 || bits > 64 {
@@ -466,35 +120,38 @@ public class MMDB {
         }
         var n = starting
         for b in 0 ..< bits {
-            if (value & (1 << (63-b))) == 0 {
-                n = node( n, side: 0)
-            } else {
-                n = node( n, side: 1)
+            
+            do {
+                if (value & (1 << (63-b))) == 0 {
+                    n = try node(n, side: 0)
+                } else {
+                    n = try node(n, side: 1)
+                }
+            } catch {
+                return .failed(error.localizedDescription)
             }
-            if n == nodeCount {
+            if n == metadata.nodeCount {
                 return .notFound
             }
-            if n > nodeCount {
-                let dataOffset = n - nodeCount - 16
-                var pointer : Int = Int( dataSectionStart + dataOffset )
-                guard let v = store.readValue(pointer: &pointer, sectionStart: Int(dataSectionStart) ) else {
+            if n > metadata.nodeCount {
+                let dataOffset = n - metadata.nodeCount - 16
+                var pointer : Int = Int(metadata.dataSectionStart + dataOffset)
+                guard let value = try? decoder.decode(&pointer, startingAt: Int(metadata.dataSectionStart)) else {
                     return .failed("Failed to read value in search")
                 }
-                return .value(v)
+                return .value(value)
             }
         }
         return .partial(n)
     }
-}
-
-extension MMDB {
-    func search<T>( value: [T], bits: Int) -> SearchResult where T : FixedWidthInteger {
+    
+    func search<T>(value: [T], bits: Int) -> SearchResult where T : FixedWidthInteger {
         var n : UInt = 0
         var togo = bits
         
         for v in value {
             let c = UInt(v) << (64 - T.bitWidth)
-            switch search( starting: n, value: c, bits: min( togo, T.bitWidth)) {
+            switch search(starting: n, value: c, bits: min( togo, T.bitWidth)) {
             case .notFound:
                 return .notFound
             case .partial(let nn):
@@ -508,56 +165,9 @@ extension MMDB {
         }
         return .partial(n)
     }
-}
-
-extension MMDB {
-    /// Get the MMDB.Value record for an IP address in text form. Does not look up host names.
-    /// You will need to use a numeric form. It accepts both IPv4 and IPv6 addresses.
-    /// - Parameter address: A numeric IPv4 or IPv6 address as accepted by `inet_addr`
-    /// or `inet_pton`
-    /// - Returns: The MMDB.Value record found, or a .notFound, or maybe a .failure if your name
-    /// was not valid.
-    public func search( address: String) -> MMDB.SearchResult {
-        let ipv4 = inet_addr(address)
-        if ipv4 != UInt32.max {
-            return search(starting: ipv4Root, value: UInt( ipv4.bigEndian)<<32, bits: 32)
-        }
-        
-        var ipv6 = in6_addr()
-        switch withUnsafeMutablePointer(to: &ipv6, ({ inet_pton(AF_INET6, address, UnsafeMutablePointer($0))})) {
-        case -1:
-            break  // error
-        case 0:
-            break  // not a valid address
-        default:
-    #if canImport(Glibc)
-        let (a,b,c,d) = ipv6.__in6_u.__u6_addr32
-    #else
-        let (a,b,c,d) = ipv6.__u6_addr.__u6_addr32
-    #endif
-            let parts = [ a.bigEndian, b.bigEndian, c.bigEndian, d.bigEndian]
-            var n : UInt = 0
-            for p in parts {
-                switch search(starting: n, value: UInt(p)<<32, bits: 32) {
-                case .notFound:
-                    return .notFound
-                case .partial(let nn):
-                    n = nn
-                case .value(let v):
-                    return .value(v)
-                case .failed(let m):
-                    return .failed(m)
-                }
-            }
-        }
-        
-        return .notFound
-    }
-}
-
-extension MMDB {
-    public func enumerate( _ handler: ([UInt32],Int)->Void ) {
-        func crunch( _ path: [UInt8]) -> [UInt32] {
+    
+    public func enumerate(_ handler: ([UInt32], Int) throws -> Void) throws {
+        func crunch(_ path: [UInt8]) -> [UInt32] {
             var result : [UInt32] = []
             var accumulate : UInt32 = 0
             
@@ -575,28 +185,66 @@ extension MMDB {
             return result
         }
         
-        func doNode( _ n: UInt, path: [UInt8] ) {
+        func doNode(_ n: UInt, path: [UInt8]) throws {
             // Catch and abort loops in the search tree
-            if ipVersion == 4 && path.count >= 32 { return }
-            if ipVersion == 6 && path.count >= 128 { return }
+            if metadata.ipVersion == 4 && path.count >= 32 { return }
+            if metadata.ipVersion == 6 && path.count >= 128 { return }
             
-            let left = node( n, side: 0)
-            if left > nodeCount {
-                handler( crunch(path + [0]), path.count+1 )
-            } else if left < nodeCount {
-                doNode( left, path: path + [0])
+            let left = try node(n, side: 0)
+            if left > metadata.nodeCount {
+                try handler(crunch(path + [0]), path.count+1 )
+            } else if left < metadata.nodeCount {
+                try doNode( left, path: path + [0])
             }
             // = nodeCount means 'not found'
             
-            let right = node( n, side:1)
-            if right > nodeCount {
-                handler( crunch(path + [1]), path.count+1)
-            } else if right < nodeCount {
-                doNode( right, path: path + [1])
+            let right = try node(n, side:1)
+            if right > metadata.nodeCount {
+                try handler(crunch(path + [1]), path.count+1)
+            } else if right < metadata.nodeCount {
+                try doNode(right, path: path + [1])
             }
             // = nodeCount means 'not found'
         }
         
-        doNode( 0, path:[])
+        try doNode(0, path:[])
+    }
+    
+    // MARK: - Nodes
+    
+    private func node(_ number: UInt, side: UInt) throws -> UInt {
+        switch metadata.recordSize {
+        case 24:
+            return try node6(number, side: side)
+        case 28:
+            return try node7(number, side: side)
+        case 32:
+            return try node8(number, side: side)
+        default:
+            throw MMDBError.unsupportedRecordSize
+        }
+    }
+    
+    func node6(_ number: UInt, side: UInt) throws -> UInt {
+        let bytesToRead = 3
+        let base = side == 0 ? Int(number * 6) : Int(number * 6) + bytesToRead
+        return UInt(Decoder.decodeUInt32(from: try fileStream.read(from: base, numberOfBytes: bytesToRead)))
+    }
+    
+    func node7(_ number: UInt, side: UInt) throws -> UInt {
+        let bytesToRead = 3
+        var base = Int(number * 7)
+        let middle = fileStream[base + bytesToRead]
+        base += side == 0 ? 0 : bytesToRead + 1
+        let relevantMiddleBits = side == 0 ? middle >> 4 : middle & 0x0f
+        var bytes = try fileStream.read(from: base, numberOfBytes: bytesToRead)
+        bytes.insert(relevantMiddleBits, at: bytes.indices.startIndex)
+        return (UInt(Decoder.decodeUInt32(from: bytes)))
+    }
+    
+    func node8(_ number: UInt, side: UInt) throws -> UInt {
+        let bytesToRead = 4
+        let base = side == 0 ? Int(number * 8) : Int(number * 8) + bytesToRead
+        return UInt(Decoder.decodeUInt32(from: try fileStream.read(from: base, numberOfBytes: bytesToRead)))
     }
 }

--- a/Sources/MMDB/MMDBError.swift
+++ b/Sources/MMDB/MMDBError.swift
@@ -1,0 +1,11 @@
+enum MMDBError: Error {
+    case indexOutOfRange
+    case unsupportedRecordSize
+    case invalidDatabaseType(_ databaseType: String)
+    case invalidFieldType(_ FieldType: UInt8)
+    case unknownFieldType(_ fieldType: UInt8)
+    case notFound(_ at: String)
+    case metadataError(_ description: String)
+    case corruptDatabase(_ description: String)
+    case decodingError(_ description: String)
+}

--- a/Sources/MMDB/Metadata.swift
+++ b/Sources/MMDB/Metadata.swift
@@ -1,0 +1,64 @@
+struct Metadata {
+    let nodeCount: UInt
+    let recordSize: UInt
+    let ipVersion: UInt
+    let databaseType: String
+    let languages: [Decoder.Value]
+    let majorVersion: UInt
+    let minorVersion: UInt
+    let epoch: UInt
+    let description: [String: Decoder.Value]
+
+    let searchTreeSize: UInt
+    let dataSectionStart: UInt
+    let nodeByteSize: Int
+    
+    init(_ metadata: [String: Decoder.Value]) throws {
+        guard case let .uint16(major) = metadata["binary_format_major_version"],
+              case let .uint16(minor) = metadata["binary_format_minor_version"] else {
+            throw MMDBError.metadataError("Could not find database version")
+        }
+        
+        if major < 2 {
+            throw MMDBError.metadataError("Database is not of major version 2")
+        }
+        
+        self.majorVersion = UInt(major)
+        self.minorVersion = UInt(minor)
+        
+        guard case let .uint64(epoch) = metadata["build_epoch"] else {
+            throw MMDBError.metadataError("Could not decode build epoch")
+        }
+        guard case let .uint16(ipVersion) = metadata["ip_version"] else {
+            throw MMDBError.metadataError("Could not decode ip version")
+        }
+        guard case let .uint16(recordSize) = metadata["record_size"] else {
+            throw MMDBError.metadataError("Could not decode record size")
+        }
+        guard case let .uint32(nodeCount) = metadata["node_count"] else {
+            throw MMDBError.metadataError("Could not decode node count")
+        }
+        guard case let .string(databaseType) = metadata["database_type"] else {
+            throw MMDBError.metadataError("Could not decode database type")
+        }
+        
+        self.epoch = UInt(epoch)
+        self.ipVersion = UInt(ipVersion)
+        self.recordSize = UInt(recordSize)
+        self.nodeByteSize = Int(recordSize / 4)
+        self.nodeCount = UInt(nodeCount)
+        self.databaseType = databaseType
+        
+        guard case let .array(languages) = metadata["languages"],
+              case let .map(description) = metadata["description"]
+        else {
+            throw MMDBError.metadataError("Could not decode languages or description")
+        }
+        self.languages = languages
+        self.description = description
+        
+        self.searchTreeSize = ((self.recordSize * 2) / 8) * self.nodeCount
+        
+        self.dataSectionStart = searchTreeSize + 16
+    }
+}

--- a/Tests/MMDBTests/GeoLite2_Tests.swift
+++ b/Tests/MMDBTests/GeoLite2_Tests.swift
@@ -27,12 +27,12 @@ class GeoLite2_Tests: XCTestCase {
             return
         }
         
-        guard let db = GeoLite2CountryDatabase(from: fileURL) else {
+        guard let db = try? GeoLite2CountryDatabase(from: fileURL) else {
             XCTFail("Failed to open MMDB")
             return
         }
         
-        XCTAssertEqual(db.databaseType, "GeoLite2-Country")
+        XCTAssertEqual(db.metadata.databaseType, "GeoLite2-Country")
         
         guard case let .value(core) = db.search(address: "2.125.160.216") else {
             XCTFail("Failed to search some EU address")
@@ -46,7 +46,7 @@ class GeoLite2_Tests: XCTestCase {
         }
         somewhere.dump()
         
-        XCTAssertEqual( db.countryCode(address: "2001:270::0"), "KR")
+        XCTAssertEqual(try db.countryCode(address: "2001:270::0"), "KR")
 
     }
 
@@ -56,7 +56,7 @@ class GeoLite2_Tests: XCTestCase {
             return
         }
 
-        guard let db = GeoLite2CountryDatabase(from: fileURL) else {
+        guard let db = try? GeoLite2CountryDatabase(from: fileURL) else {
             XCTFail("Failed to open MMDB")
             return
         }
@@ -93,7 +93,7 @@ class GeoLite2_Tests: XCTestCase {
             return
         }
 
-        guard let db = GeoLite2CountryDatabase(from: fileURL) else {
+        guard let db = try? GeoLite2CountryDatabase(from: fileURL) else {
             XCTFail("Failed to open MMDB")
             return
         }

--- a/Tests/MMDBTests/MMDB_Tests.swift
+++ b/Tests/MMDBTests/MMDB_Tests.swift
@@ -16,14 +16,14 @@ let someIPv4Addresses = [ "2.125.160.216",
                           "217.65.48.0" ]
 
 final class MMDB_Tests: XCTestCase {
-    func readAllAcceptErrors( forResource: String, withExtension: String = "mmdb", subdirectory: String) {
-        guard let fileURL = Bundle.module.url(forResource: forResource, withExtension: withExtension, subdirectory: subdirectory),
-              let mmdb = MMDB(from: fileURL) else {
-            XCTFail("Failed to open MMDB")
+    func readAllAcceptErrors(forResource name: String, withExtension ext: String = "mmdb", subdirectory subpath: String) throws {
+        guard let fileURL = Bundle.module.url(forResource: name, withExtension: ext, subdirectory: subpath) else {
+            XCTFail("Could not find resource \(name) with extension \(ext) in subpath \(subpath).")
             return
         }
-
-        mmdb.enumerate{ (bits:[UInt32], count: Int) in
+        let mmdb = try MMDB(from: fileURL)
+        
+        try mmdb.enumerate{ bits, count in
             let hex = bits.reduce("") { $0 +  String(format:"%08x", $1) }
             print( "\(hex)/\(count)" )
             
@@ -40,19 +40,19 @@ final class MMDB_Tests: XCTestCase {
         }
     }
 
-    func readAll( forResource: String, withExtension: String = "mmdb", subdirectory: String) {
-        guard let fileURL = Bundle.module.url(forResource: forResource, withExtension: withExtension, subdirectory: subdirectory),
-              let mmdb = MMDB(from: fileURL) else {
+    func readAll(forResource: String, withExtension: String = "mmdb", subdirectory: String) throws {
+        guard let fileURL = Bundle.module.url(forResource: forResource, withExtension: withExtension, subdirectory: subdirectory) else {
             XCTFail("Failed to open MMDB")
             return
         }
+        let mmdb = try MMDB(from: fileURL)
         
-        mmdb.enumerate{ (bits:[UInt32], count: Int) in
+        try mmdb.enumerate{ bits, count in
             let hex = bits.reduce("") { $0 +  String(format:"%08x", $1) }
             print( "\(hex)/\(count)" )
             
             guard case let .value(v) = mmdb.search(value: bits, bits: count) else {
-                XCTFail("failed to searc \(hex)/\(count)")
+                XCTFail("failed to search \(hex)/\(count)")
                 return
             }
             v.dump()
@@ -68,7 +68,7 @@ final class MMDB_Tests: XCTestCase {
             return
         }
         
-        guard let mmdb = MMDB(from: fileURL) else {
+        guard let mmdb = try? MMDB(from: fileURL) else {
             XCTFail("Failed to open MMDB")
             return
         }
@@ -87,173 +87,170 @@ final class MMDB_Tests: XCTestCase {
     }
     
     func testIPv4_24() throws {
-        readAll(forResource: "MaxMind-DB-test-ipv4-24", subdirectory: "test-data")
+        try readAll(forResource: "MaxMind-DB-test-ipv4-24", subdirectory: "test-data")
     }
     
     func testIPv4_28() throws {
-        readAll(forResource: "MaxMind-DB-test-ipv4-28", subdirectory: "test-data")
+        try readAll(forResource: "MaxMind-DB-test-ipv4-28", subdirectory: "test-data")
     }
 
     func testIPv4_32() throws {
-        readAll(forResource: "MaxMind-DB-test-ipv4-32", subdirectory: "test-data")
+        try readAll(forResource: "MaxMind-DB-test-ipv4-32", subdirectory: "test-data")
     }
 
     func testIPv6_24() throws {
-        readAll(forResource: "MaxMind-DB-test-ipv6-24", subdirectory: "test-data")
+        try readAll(forResource: "MaxMind-DB-test-ipv6-24", subdirectory: "test-data")
     }
     
     func testIPv6_28() throws {
-        readAll(forResource: "MaxMind-DB-test-ipv6-28", subdirectory: "test-data")
+        try readAll(forResource: "MaxMind-DB-test-ipv6-28", subdirectory: "test-data")
     }
 
     func testIPv6_32() throws {
-        readAll(forResource: "MaxMind-DB-test-ipv6-32", subdirectory: "test-data")
+        try readAll(forResource: "MaxMind-DB-test-ipv6-32", subdirectory: "test-data")
     }
 
     func testIP_24() throws {
-        readAll(forResource: "MaxMind-DB-test-mixed-24", subdirectory: "test-data")
+        try readAll(forResource: "MaxMind-DB-test-mixed-24", subdirectory: "test-data")
     }
     
     func testIP_28() throws {
-        readAll(forResource: "MaxMind-DB-test-mixed-28", subdirectory: "test-data")
+        try readAll(forResource: "MaxMind-DB-test-mixed-28", subdirectory: "test-data")
     }
 
     func testIP_32() throws {
-        readAll(forResource: "MaxMind-DB-test-mixed-32", subdirectory: "test-data")
+        try readAll(forResource: "MaxMind-DB-test-mixed-32", subdirectory: "test-data")
     }
 
     func testNested() throws {
-        readAll(forResource: "MaxMind-DB-test-nested", subdirectory: "test-data")
+        try readAll(forResource: "MaxMind-DB-test-nested", subdirectory: "test-data")
     }
 
     func testPointerDecoder() throws {
-        readAll(forResource: "MaxMind-DB-test-pointer-decoder", subdirectory: "test-data")
+        try readAll(forResource: "MaxMind-DB-test-pointer-decoder", subdirectory: "test-data")
     }
 
     func testDecoder() throws {
-        readAll(forResource: "MaxMind-DB-test-decoder", subdirectory: "test-data")
+        try readAll(forResource: "MaxMind-DB-test-decoder", subdirectory: "test-data")
     }
 
     func testMetadataPointers() throws {
-        readAll(forResource: "MaxMind-DB-test-metadata-pointers", subdirectory: "test-data")
+        try readAll(forResource: "MaxMind-DB-test-metadata-pointers", subdirectory: "test-data")
     }
 
     func testStringValueEntries() throws {
-        readAll(forResource: "MaxMind-DB-string-value-entries", subdirectory: "test-data")
+        try readAll(forResource: "MaxMind-DB-string-value-entries", subdirectory: "test-data")
     }
 
     func testNoIPv4SearchTree() throws {
-        readAll(forResource: "MaxMind-DB-no-ipv4-search-tree", subdirectory: "test-data")
+        try readAll(forResource: "MaxMind-DB-no-ipv4-search-tree", subdirectory: "test-data")
     }
 
     func testBrokenPointers24() throws {
-        readAllAcceptErrors(forResource: "MaxMind-DB-test-broken-pointers-24", subdirectory: "test-data")
+        try readAllAcceptErrors(forResource: "MaxMind-DB-test-broken-pointers-24", subdirectory: "test-data")
     }
 
     func testBrokenSearchTree() throws {
-        readAllAcceptErrors(forResource: "MaxMind-DB-test-broken-search-tree-24", subdirectory: "test-data")
+        try readAllAcceptErrors(forResource: "MaxMind-DB-test-broken-search-tree-24", subdirectory: "test-data")
     }
 
     func testGeoIP2AnonymousIP() throws {
-        readAll(forResource: "GeoIP2-Anonymous-IP-Test", subdirectory: "test-data")
+        try readAll(forResource: "GeoIP2-Anonymous-IP-Test", subdirectory: "test-data")
     }
 
     func testGeoIP2CityTest() throws {
-        readAll(forResource: "GeoIP2-City-Test", subdirectory: "test-data")
+        try readAll(forResource: "GeoIP2-City-Test", subdirectory: "test-data")
     }
 
     func testGeoIP2ConnectionTypeTest() throws {
-        readAll(forResource: "GeoIP2-Connection-Type-Test", subdirectory: "test-data")
+        try readAll(forResource: "GeoIP2-Connection-Type-Test", subdirectory: "test-data")
     }
 
     func testGeoIP2DensityIncomeTest() throws {
-        readAll(forResource: "GeoIP2-DensityIncome-Test", subdirectory: "test-data")
+        try readAll(forResource: "GeoIP2-DensityIncome-Test", subdirectory: "test-data")
     }
 
     func testGeoIP2DomainTest() throws {
-        readAll(forResource: "GeoIP2-Domain-Test", subdirectory: "test-data")
+        try readAll(forResource: "GeoIP2-Domain-Test", subdirectory: "test-data")
     }
 
     func testGeoIP2EnterpriseTest() throws {
-        readAll(forResource: "GeoIP2-Enterprise-Test", subdirectory: "test-data")
+        try readAll(forResource: "GeoIP2-Enterprise-Test", subdirectory: "test-data")
     }
 
     func testGeoIP2ISPTest() throws {
-        readAll(forResource: "GeoIP2-ISP-Test", subdirectory: "test-data")
+        try readAll(forResource: "GeoIP2-ISP-Test", subdirectory: "test-data")
     }
 
     func testGeoIP2PrecisionEnterpriseTest() throws {
-        readAll(forResource: "GeoIP2-Precision-Enterprise-Test", subdirectory: "test-data")
+        try readAll(forResource: "GeoIP2-Precision-Enterprise-Test", subdirectory: "test-data")
     }
 
     func testGeoIP2StaticIPScoreTest() throws {
-        readAll(forResource: "GeoIP2-Static-IP-Score-Test", subdirectory: "test-data")
+        try readAll(forResource: "GeoIP2-Static-IP-Score-Test", subdirectory: "test-data")
     }
 
     func testGeoIP2UserCountTest() throws {
-        readAll(forResource: "GeoIP2-User-Count-Test", subdirectory: "test-data")
+        try readAll(forResource: "GeoIP2-User-Count-Test", subdirectory: "test-data")
     }
 
     func testGeoLite2ASNTest() throws {
-        readAll(forResource: "GeoLite2-ASN-Test", subdirectory: "test-data")
+        try readAll(forResource: "GeoLite2-ASN-Test", subdirectory: "test-data")
     }
 
     func testGeoLite2CityTest() throws {
-        readAll(forResource: "GeoLite2-City-Test", subdirectory: "test-data")
+        try readAll(forResource: "GeoLite2-City-Test", subdirectory: "test-data")
     }
 
     func testGeoLite2CountryTest() throws {
-        readAll(forResource: "GeoLite2-Country-Test", subdirectory: "test-data")
+        try readAll(forResource: "GeoLite2-Country-Test", subdirectory: "test-data")
     }
 
     func testGeoIP2CityTestBrokenDoubleFormat() throws {
-        readAllAcceptErrors(forResource: "GeoIP2-City-Test-Broken-Double-Format", subdirectory: "test-data")
+        try readAllAcceptErrors(forResource: "GeoIP2-City-Test-Broken-Double-Format", subdirectory: "test-data")
     }
 
     func testGeoIP2CityTestInvalidNodeCount() throws {
         guard let fileURL = Bundle.module.url(forResource: "GeoIP2-City-Test-Invalid-Node-Count", withExtension: "mmdb", subdirectory: "test-data"),
-              let mmdb = MMDB(from: fileURL) else {
+              let mmdb = try? MMDB(from: fileURL) else {
             return
         }
-        XCTFail("Opened MMDB with insane node count: \(mmdb.nodeCount)")
+        XCTFail("Opened MMDB with insane node count: \(mmdb.metadata.nodeCount)")
     }
 
     func testCyclicDataStructure() throws {
-        readAllAcceptErrors(forResource: "cyclic-data-structure", subdirectory: "bad-data/maxminddb-golang")
+        XCTAssertThrowsError(try readAllAcceptErrors(forResource: "cyclic-data-structure", subdirectory: "bad-data/maxminddb-golang"))
     }
     
     func testInvalidBytesLength() throws {
-        readAllAcceptErrors(forResource: "invalid-bytes-length", subdirectory: "bad-data/maxminddb-golang")
+        XCTAssertThrowsError(try readAllAcceptErrors(forResource: "invalid-bytes-length", subdirectory: "bad-data/maxminddb-golang"))
     }
 
     func testInvalidDataRecordOffset() throws {
-        readAllAcceptErrors(forResource: "invalid-data-record-offset", subdirectory: "bad-data/maxminddb-golang")
+        XCTAssertThrowsError(try readAllAcceptErrors(forResource: "invalid-data-record-offset", subdirectory: "bad-data/maxminddb-golang"))
     }
 
     func testInvalidMapKeyLength() throws {
-        readAllAcceptErrors(forResource: "invalid-map-key-length", subdirectory: "bad-data/maxminddb-golang")
+        XCTAssertThrowsError(try readAllAcceptErrors(forResource: "invalid-map-key-length", subdirectory: "bad-data/maxminddb-golang"))
     }
 
     func testInvalidStringLength() throws {
-        readAllAcceptErrors(forResource: "invalid-string-length", subdirectory: "bad-data/maxminddb-golang")
+        XCTAssertThrowsError(try readAllAcceptErrors(forResource: "invalid-string-length", subdirectory: "bad-data/maxminddb-golang"))
     }
 
     func testMetadataIsAnUInt128() throws {
-        readAllAcceptErrors(forResource: "metadata-is-an-uint128", subdirectory: "bad-data/maxminddb-golang")
+        XCTAssertThrowsError(try readAllAcceptErrors(forResource: "metadata-is-an-uint128", subdirectory: "bad-data/maxminddb-golang"))
     }
 
     func testUnexpectedBytes() throws {
-        readAllAcceptErrors(forResource: "unexpected-bytes", subdirectory: "bad-data/maxminddb-golang")
+        XCTAssertThrowsError(try readAllAcceptErrors(forResource: "unexpected-bytes", subdirectory: "bad-data/maxminddb-golang"))
     }
 
     func testBadUnicodeInMapKey() throws {
-        readAllAcceptErrors(forResource: "bad-unicode-in-map-key", subdirectory: "bad-data/maxminddb-python")
+        try readAllAcceptErrors(forResource: "bad-unicode-in-map-key", subdirectory: "bad-data/maxminddb-python")
     }
 
     func testOffsetIntegerOverflow() throws {
-        readAllAcceptErrors(forResource: "libmaxminddb-offset-integer-overflow", subdirectory: "bad-data/maxminddb-golang")
+        XCTAssertThrowsError(try readAllAcceptErrors(forResource: "libmaxminddb-offset-integer-overflow", subdirectory: "bad-data/libmaxminddb"))
     }
-
-
 }
-


### PR DESCRIPTION
This pull request resolves an error occurring on GeoLite2 City databases where some IP-Addresses could not be resolved properly and always returned a read error. 

The issue there was, as far as I can tell, in the handling of pointers. However, I took the liberty to rewrite some parts of the decoder and restructured the entire codebase into multiple structs and files for (in my opinion) better readability. 

While doing that I also added better error handling with a `MMDBError` `enum` that is thrown when encountering errors instead of returning `nil` or `fatalError`.

All tests finish as before but I wrapped the tests supposed to fail with `XCTAssertThrowsError` so the test itself is marked as successful.

Finally I would like to thank you for the effort you put into this amazing project and hope you can incorporate the suggested changes. 